### PR TITLE
Removing the registry and building images with the executor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/docker/docker v25.0.2+incompatible
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/go-containerregistry v0.19.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/invopop/jsonschema v0.12.0
 	github.com/mattn/go-sqlite3 v1.14.22
@@ -19,6 +20,7 @@ require (
 	github.com/pressly/goose/v3 v3.18.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/net v0.19.0
+	golang.org/x/sync v0.7.0
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
@@ -84,7 +86,6 @@ require (
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
@@ -160,7 +161,6 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
-	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,6 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
-github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -935,8 +933,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -54,8 +54,7 @@ type Config struct {
 }
 
 type Local struct {
-	BucketPort   string
-	RegistryPort string
+	BucketPort string
 }
 
 type Cloud struct {
@@ -300,7 +299,7 @@ func main() {
 			CheckOrigin: func(r *http.Request) bool {
 				// Allow specific origin
 				origin := r.Header.Get("Origin")
-				return strings.HasPrefix(origin, "http://localhost") || strings.HasPrefix(origin, "http://127.0.0.1") || strings.HasPrefix(origin, "file://") 
+				return strings.HasPrefix(origin, "http://localhost") || strings.HasPrefix(origin, "http://127.0.0.1") || strings.HasPrefix(origin, "file://")
 			},
 
 			ReadBufferSize:  1024,

--- a/translator.go
+++ b/translator.go
@@ -122,38 +122,7 @@ func blockTemplate(block *zjson.Block, blockKey string, organization string, cfg
 
 func kanikoTemplate(block *zjson.Block, organization string, cfg Config) *wfv1.Template {
 	if cfg.IsLocal {
-		name := block.Action.Container.Image + "-" + block.Action.Container.Version
-		cmd := []string{
-			"/kaniko/executor",
-			"--context",
-			"tar:///workspace/context.tar.gz",
-			"--destination",
-			"registry:" + cfg.Local.RegistryPort + "/" + block.Action.Container.Image + ":" + block.Action.Container.Version,
-			"--insecure",
-			"--compressed-caching=false",
-			"--snapshotMode=redo",
-			"--use-new-run",
-		}
-		artifact := wfv1.Artifact{
-			Name: "context",
-			Path: "/workspace/context.tar.gz",
-			ArtifactLocation: wfv1.ArtifactLocation{
-				S3: &wfv1.S3Artifact{
-					Key: name + "-build.tar.gz",
-				},
-			},
-			Archive: &wfv1.ArchiveStrategy{
-				None: &wfv1.NoneStrategy{},
-			},
-		}
-		return &wfv1.Template{
-			Name: name + "-build",
-			Container: &corev1.Container{
-				Image:   cfg.KanikoImage,
-				Command: cmd,
-			},
-			Inputs: wfv1.Inputs{Artifacts: []wfv1.Artifact{artifact}},
-		}
+		return nil
 	} else {
 		name := organization + "-" + block.Action.Container.Image + "-" + block.Action.Container.Version
 		cmd := []string{

--- a/zetaforge/utils/build.yaml
+++ b/zetaforge/utils/build.yaml
@@ -104,38 +104,3 @@ spec:
   selector:
     app.kubernetes.io/name: weed
   type: LoadBalancer
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/name: registry
-  name: registry
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: registry
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: registry
-    spec:
-      containers:
-      - image: registry:2
-        name: registry
-        ports:
-        - containerPort: 5000
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: registry
-spec:
-  loadBalancerIP: null
-  ports:
-  - port: 5000
-    targetPort: 5000
-  selector:
-    app.kubernetes.io/name: registry
-  type: LoadBalancer


### PR DESCRIPTION
This MR intends to remove the running registry for local use and build image directly into docker to take advantage of the cache.

For docker-desktop it might be worth informing users that disabling SBOM is recommend to avoid heavy lag caused by docker-scout.
![image](https://github.com/zetane/ZetaForge/assets/45149203/ce7805ab-707e-4c5f-a1a1-c67d99ef71eb)
