### PR TITLE
Improve Mixpanel and Sentry trackings. 

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,5 +13,6 @@
 	"Local": {
 		"BucketPort": 8333,
 		"Driver": "docker-desktop"
-	}
+	},
+	"ZetaforgeIsDev": true
 } 

--- a/executor.go
+++ b/executor.go
@@ -319,8 +319,9 @@ func streaming(ctx context.Context, sink string, name string, room string, clien
 }
 
 func runArgo(ctx context.Context, workflow *wfv1.Workflow, sink string, pipeline string, execution int64, client clientcmd.ClientConfig, db *sql.DB, hub *Hub) (*wfv1.Workflow, error) {
-	mixpanelClient := InitMixpanelClient("4c09914a48f08de1dbe3dc4dd2dcf90d", ctx)
-
+	//mixpanelClient is singleton, so a new instance won't be created.
+	mixpanelClient := GetMixpanelClient()
+	
 	
 	
 	ctx, cli, err := apiclient.NewClientFromOpts(

--- a/executor.go
+++ b/executor.go
@@ -16,7 +16,6 @@ import (
 	"runtime"
 	"strings"
 	"time"
-
 	"server/zjson"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient"
@@ -320,6 +319,10 @@ func streaming(ctx context.Context, sink string, name string, room string, clien
 }
 
 func runArgo(ctx context.Context, workflow *wfv1.Workflow, sink string, pipeline string, execution int64, client clientcmd.ClientConfig, db *sql.DB, hub *Hub) (*wfv1.Workflow, error) {
+	mixpanelClient := InitMixpanelClient("4c09914a48f08de1dbe3dc4dd2dcf90d", ctx)
+
+	
+	
 	ctx, cli, err := apiclient.NewClientFromOpts(
 		apiclient.Opts{
 			ClientConfigSupplier: func() clientcmd.ClientConfig {
@@ -370,7 +373,10 @@ func runArgo(ctx context.Context, workflow *wfv1.Workflow, sink string, pipeline
 		}
 
 		if workflow.Status.Phase.Completed() {
+			
+			
 			log.Printf("Status: Completed")
+			mixpanelClient.TrackEvent(ctx, "Run Completed", map[string]any{})
 			break
 		}
 		time.Sleep(time.Second)

--- a/frontend/.env
+++ b/frontend/.env
@@ -4,4 +4,3 @@ VITE_CACHE_DIR=".cache"
 VITE_BUCKET="zetaforge"
 VITE_S3_ENDPOINT="http://localhost:8333"
 VITE_DISABLE_MIXPANEL="False"
-

--- a/frontend/electron/main/index.ts
+++ b/frontend/electron/main/index.ts
@@ -33,6 +33,14 @@ process.env.VITE_PUBLIC = process.env.VITE_DEV_SERVER_URL
   ? join(process.env.DIST_ELECTRON, '../public')
   : process.env.DIST
 
+const targetValue = '--is_dev'
+const targetIndex = process.argv.indexOf(targetValue);
+if (targetIndex !== -1) {
+  const value = process.argv[targetIndex];
+  process.env.VITE_ZETAFORGE_IS_DEV = 'True'
+} else {
+  process.env.VITE_ZETAFORGE_IS_DEV = 'False'
+}
 
 // Disable GPU Acceleration for Windows 7
 if (release().startsWith('6.1')) app.disableHardwareAcceleration()

--- a/frontend/server/express.mjs
+++ b/frontend/server/express.mjs
@@ -314,6 +314,10 @@ function startExpressServer() {
     }
 });
 
+app.get("/is-dev", async(req, res) => {
+  return res.send( !electronApp.isPackaged || (electronApp.isPackaged && process.env.VITE_ZETAFORGE_IS_DEV === 'True') )
+})
+
    
   
 

--- a/frontend/src/components/ui/MixpanelService.js
+++ b/frontend/src/components/ui/MixpanelService.js
@@ -9,6 +9,7 @@ class MixpanelService {
         mixpanel.init(token);
         this.distinctId = null
         this.token = token
+        this.isDev = null
       } catch(err) {
         this.disabled = true
       }
@@ -20,11 +21,19 @@ class MixpanelService {
           const serverAddress = import.meta.env.VITE_EXPRESS
           const res = await fetch(`${serverAddress}/distinct-id`)
           this.distinctId = await res.text()
+          this.isDev = await this.checkIsDev()
         } catch(err) {
             console.log("Err while initializing distinct id")
             console.log(err)
             this.disabled = true
         }
+    }
+
+    async checkIsDev(){
+      const serverAddress = import.meta.env.VITE_EXPRESS
+      const res = await fetch(`${serverAddress}/is-dev`)
+      const data = await res.json()
+      return data
     }
 
 
@@ -43,7 +52,7 @@ class MixpanelService {
         mixpanel.identify(this.distinctId)
         mixpanel.people.set_once()
 
-        mixpanel.track(eventName, {...eventData, distinct_id: this.distinctId});
+        mixpanel.track(eventName, {...eventData, distinct_id: this.distinctId, is_dev:this.isDev});
       } catch(err) {
         this.disabled = true
       }

--- a/frontend/src/components/ui/RunPipelineButton.jsx
+++ b/frontend/src/components/ui/RunPipelineButton.jsx
@@ -10,6 +10,7 @@ import { useState, useEffect, useRef } from "react";
 import ClosableModal from "./modal/ClosableModal";
 import { S3Client, HeadObjectCommand } from '@aws-sdk/client-s3'
 import { trpc } from "@/utils/trpc";
+import { mixpanelAtom } from "@/atoms/mixpanelAtom";
 
 const BUCKET = import.meta.env.VITE_BUCKET
 
@@ -22,6 +23,7 @@ export default function RunPipelineButton({modalPopper, children, action}) {
   const [angle, setAngle] = useState(0)
   const posRef = useRef({ x: 0, y: 0 });
   const velocityRef = useRef({ x: 2, y: 2 });
+  const [mixpanelService] = useAtom(mixpanelAtom)
 
   const s3Uploader = trpc.uploadToS3.useMutation()
 
@@ -144,6 +146,12 @@ export default function RunPipelineButton({modalPopper, children, action}) {
           draft.log = []
         })
       }
+      try {
+        mixpanelService.trackEvent('Run Created')
+      } catch (err) {
+  
+      }
+      
     } catch (error) {
 
     }

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/invopop/jsonschema v0.12.0
+	github.com/kaganAtZetane/mixpanel-go v0.0.0-20240503162028-cb57796e81a9
 	github.com/mattn/go-sqlite3 v1.14.22
-	github.com/mixpanel/mixpanel-go v1.2.1
 	github.com/pressly/goose/v3 v3.18.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/net v0.23.0
@@ -107,6 +107,7 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -396,6 +398,9 @@ github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/kaganAtZetane/mixpanel-go v0.0.0-20240503162028-cb57796e81a9 h1:h/S3u3S6hzHdvpMRN4WqU80I+RKUxyYiCNTmCcpQigU=
+github.com/kaganAtZetane/mixpanel-go v0.0.0-20240503162028-cb57796e81a9/go.mod h1:GICq6WB8JROuCxEaKXucd4VYsSIpsCmx81gp8DPYx40=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -462,8 +467,6 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mixpanel/mixpanel-go v1.2.1 h1:iykbHKomTJjVoWU95Vt1sjZy4HLt8UOYacMEEEMFBok=
-github.com/mixpanel/mixpanel-go v1.2.1/go.mod h1:mPGaNhBoZMJuLu8k7Y1KhU5n8Vw13rxQZZjHj+b9RLk=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=

--- a/main.go
+++ b/main.go
@@ -135,6 +135,9 @@ func setupSentry() {
 }
 
 func main() {
+	//Initialize mixpanelClient only once(it's singleton)
+	ctx := context.Background()
+	mixpanelClient = InitMixpanelClient("4c09914a48f08de1dbe3dc4dd2dcf90d", ctx)
 	setupSentry()
 	file, err := os.ReadFile("config.json")
 	if err != nil {

--- a/mixpanelUtilities.go
+++ b/mixpanelUtilities.go
@@ -94,7 +94,7 @@ func InitMixpanelClient(token string, ctx context.Context) *MixpanelClient {
 	once.Do(func() {
 		client := mixpanel.NewApiClient(token)
 		file, err := os.ReadFile("config.json")
-
+defer file.Close()
 		var isDev bool
 		enabled := true
 		if err != nil {

--- a/mixpanelUtilities.go
+++ b/mixpanelUtilities.go
@@ -1,0 +1,186 @@
+package main
+
+import ("math/big"
+"net"
+"context"
+"strings"
+"os"
+"crypto/sha256"
+"encoding/hex"
+"encoding/json"
+"fmt"
+"log"
+"github.com/kaganAtZetane/mixpanel-go"
+"runtime"
+)
+
+
+
+func generateDistinctID() (string) {
+	_, macInt, err := getMACAddress()
+	if err != nil {
+		log.Printf("Mixpanel error; err=%v", err)
+	}
+
+	macAsString := macInt.String()
+	hash := sha256.New()
+	hash.Write([]byte(macAsString))
+	hashedResult := hash.Sum(nil)
+	distinctID := hex.EncodeToString(hashedResult)
+	return distinctID
+}
+
+func macAddressToDecimal(mac string) (*big.Int, error) {
+	macWithoutColons := strings.ReplaceAll(mac, ":", "")
+
+	macBytes, err := hex.DecodeString(macWithoutColons)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert the byte slice to a BigInt
+	macAsBigInt := new(big.Int).SetBytes(macBytes)
+
+	return macAsBigInt, nil
+
+}
+
+func getMACAddress() (string, *big.Int, error) {
+
+	// return value: big Int, which is MAC address of the device. In the case of Failure, we return zero, as big Int.
+
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Find the first non-loopback interface with a hardware address
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagLoopback == 0 && len(iface.HardwareAddr) > 0 {
+			macAddress := iface.HardwareAddr.String()
+			macInt, err := macAddressToDecimal(macAddress)
+			if err != nil {
+				return "", nil, err
+			}
+			return macAddress, macInt, nil
+		}
+	}
+
+	return "", new(big.Int).SetInt64(int64(0)), fmt.Errorf("unable to determine distinct_id, using default distinct_id")
+}
+
+
+
+type MixpanelJsonConfig struct {
+	ZetaforgeIsDev bool  `json:"ZetaforgeIsDev"`
+}
+
+type MixpanelClient struct{
+	Client 	*mixpanel.ApiClient
+	DistinctID string
+	Token string
+	Enabled bool
+	IsDev bool
+}
+
+func InitMixpanelClient(token string, ctx context.Context) *MixpanelClient {
+	client := mixpanel.NewApiClient(token)
+	file, err := os.ReadFile("config.json")
+	
+	var isDev bool
+	var enabled bool
+	if err != nil {
+		//theoratically, the code should never reach at this statement, since long before, a lack of config.json will throw an exception
+        fmt.Println("Error opening file:", err)
+        enabled = false
+	}
+
+	var raw map[string]json.RawMessage
+	
+    if err := json.Unmarshal(file, &raw); err != nil {
+        log.Fatalf("Failed to parse JSON: %v", err)
+		enabled = false
+    }
+
+	var mixpanelConfig MixpanelJsonConfig
+
+	//if the field is not provided, then is_dev is set to be true
+	if raw["ZetaforgeIsDev"] != nil {
+        
+        if err := json.Unmarshal(raw["ZetaforgeIsDev"], &isDev); err != nil {
+            log.Fatalf("Failed to parse ZetaforgeIsDev field: %v", err)
+        }
+        mixpanelConfig.ZetaforgeIsDev = isDev
+		//if the field is not provided in config.json, then we automatically set it to true
+    } else {
+        mixpanelConfig.ZetaforgeIsDev = true
+    }
+
+
+	
+	distinctID := generateDistinctID()
+	var mixpanelClient *MixpanelClient
+	mixpanelClient = &MixpanelClient{
+		Client: client,
+		DistinctID: distinctID,
+		Token: token,
+		Enabled: enabled,
+		IsDev: mixpanelConfig.ZetaforgeIsDev,
+	}
+	mixpanelClient.SetPeopleProperties(ctx,  map[string]any{ "$ip": 1})
+	return mixpanelClient
+}
+
+func (m *MixpanelClient) SetPeopleProperties(ctx context.Context, userProperties map[string]any) error {
+	if !m.Enabled {
+		return nil
+	}
+	var finalProperties = make(map[string]any)
+
+	os := runtime.GOOS
+	if os == "darwin" {
+		os = "Mac OS X"
+	}
+
+	for k,v := range userProperties {
+		finalProperties[k] = v
+	}
+	finalProperties["$os"] = os
+
+	user := mixpanel.NewPeopleProperties(m.DistinctID, finalProperties)
+	err := m.Client.PeopleSet(ctx, []*mixpanel.PeopleProperties{user})
+	if err != nil {
+		log.Printf("Mixpanel error; err=%v", err)
+		m.Enabled = false
+	}
+	return err
+}
+
+
+func (m *MixpanelClient) TrackEvent(ctx context.Context, eventName string, properties map[string]any) error {
+	if !m.Enabled {
+		return nil
+	}
+	var finalProperties = make(map[string]any)
+	os := runtime.GOOS
+	if os == "darwin" {
+		os = "Mac OS X"
+	}
+
+	for k,v := range properties {
+		finalProperties[k] = v
+	}
+	finalProperties["distinct_id"] = m.DistinctID
+	finalProperties["$os"] = os
+	finalProperties["is_dev"] = m.IsDev
+
+	
+	event := m.Client.NewEvent(eventName, m.DistinctID, finalProperties)
+	err := m.Client.Track(ctx, []*mixpanel.Event{event})
+	if err != nil {
+		log.Printf("Mixpanel error; err=%v", err)
+		m.Enabled = false
+	}
+	return err
+}
+

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'colorama==0.4.6', 
         'mixpanel==4.10.1', 
         "langchain==0.1.15", 
-        "langchain-openai==0.1.2"],
+        "langchain-openai==0.1.2",
+        "sentry-sdk===2.0.1"],
     include_package_data=True,
     package_data={'zetaforge': ['utils/*.yaml', 'executables/*'],},)

--- a/zetaforge/forge_cli.py
+++ b/zetaforge/forge_cli.py
@@ -41,7 +41,7 @@ def main():
         config = load_config(config_file)
         if config is None:
             print("Config not found! Running setup..")
-            config_file = setup(server_versions[-1], client_versions[-1], args.driver, server_path=args.s2_path)
+            config_file = setup(server_versions[-1], client_versions[-1], args.driver, server_path=args.s2_path, is_dev=args.is_dev)
             config = load_config(config_file)
 
         if config is not None:

--- a/zetaforge/forge_cli.py
+++ b/zetaforge/forge_cli.py
@@ -4,7 +4,7 @@ import argparse, os, json
 from pathlib import Path
 from .__init__ import __version__
 from colorama import init, Fore, Style
-
+from .mixpanel_client import mixpanel_client
 EXECUTABLES_PATH = os.path.join(Path(__file__).parent, 'executables')
 FRONT_END = os.path.join(EXECUTABLES_PATH, "frontend")
 
@@ -19,6 +19,7 @@ def main():
     parser.add_argument("--s2_path", "-s2",  help="Full path to local execution server. Note that this is an option for zetaforge developers, or advanced zetaforge users. If not passed, zetaforge will use the deployed application", default=None)
     parser.add_argument("--app_path", "-path",  help="Full path to local electron executable. Note that this is an option for zetaforge developers, or advanced zetaforge users. If not passed, zetaforge will use the deployed application", default=None)
     parser.add_argument("--driver", help="Defines which driver to use for kubernetes", default="docker-desktop")
+    parser.add_argument("--is_dev" , "-dev", action="store_true", help="If passed, the mixpanel events will have a field, is_dev that is set to be True")
     args = parser.parse_args()
 
     init()  # Initialize colorama
@@ -28,6 +29,7 @@ def main():
     client_path, server_path = get_launch_paths(server_versions[-1], client_versions[-1])
     if args.s2_path is not None:
         server_path = args.s2_path
+    mixpanel_client.set_env(args.is_dev)
     print(server_path)
     server_dir = os.path.dirname(server_path)
     print(server_dir)
@@ -43,7 +45,7 @@ def main():
             config = load_config(config_file)
 
         if config is not None:
-            run_forge(server_version=server_versions[-1], client_version=client_versions[-1], server_path=args.s2_path, client_path=args.app_path)
+            run_forge(server_version=server_versions[-1], client_version=client_versions[-1], server_path=args.s2_path, client_path=args.app_path, is_dev=args.is_dev)
         else:
             raise Exception("Config failed to load, please re-run `zetaforge setup`.")
     elif args.command == "teardown":
@@ -51,7 +53,7 @@ def main():
     elif args.command == 'purge':
         purge()
     elif args.command == 'setup':
-        setup(server_versions[-1], client_versions[-1], args.driver)
+        setup(server_versions[-1], client_versions[-1], args.driver, is_dev=args.is_dev)
     else:
         print('zetaforge:\t' + __version__)
         print("client:\t" + client_versions[-1])    

--- a/zetaforge/forge_runner.py
+++ b/zetaforge/forge_runner.py
@@ -195,7 +195,7 @@ def setup(server_version, client_version, driver, build_flag = True, install_fla
 
     install_frontend_dependencies(client_version=client_version)
 
-    config_path = write_json(server_version, client_version, context, driver, server_path, is_dev)
+    config_path = write_json(server_version, client_version, context, driver, is_dev, s2_path=server_path)
 
     print(f"Setup complete, wrote config to {config_path}.")
     mixpanel_client.track_event("Setup Successful")

--- a/zetaforge/forge_runner.py
+++ b/zetaforge/forge_runner.py
@@ -158,7 +158,7 @@ def setup(server_version, client_version, driver, build_flag = True, install_fla
             raise Exception("Minikube not found!")
         minikube = subprocess.run(["minikube", "-p", "zetaforge", "start"], capture_output=True, text=True)
         if minikube.returncode != 0:
-            mixpanel_client.track_event("Setup Failure - Minikube Not Found")
+            mixpanel_client.track_event("Setup Failure - Cannot Start Minikube")
             time.sleep(0.5)
             print(minikube.stderr)
             raise Exception("Error while starting minikube")
@@ -284,7 +284,7 @@ def run_forge(server_version=None, client_version=None, server_path=None, client
         client_stdout_thread.join()
         client_stderr_thread.join()
 
-        mixpanel_client.track_event('Launch Successful', props={'Duration(seconds)': total_time})
+        mixpanel_client.track_event('Launch Successful')
 
     except KeyboardInterrupt: 
         print("Terminating servers..")
@@ -293,7 +293,7 @@ def run_forge(server_version=None, client_version=None, server_path=None, client
         total_time = (datetime.now() - time_start).total_seconds()
 
         try:
-            mixpanel_client.track_event('Launch Exit', props={'Duration(seconds)': total_time})
+            mixpanel_client.track_event('Launch End', props={'Duration(seconds)': total_time})
             time.sleep(2) # mixpanel instance is asynch, so making sure that it completes the call before tear down
         except:
             print("Mixpanel cannot track")

--- a/zetaforge/mixpanel.py
+++ b/zetaforge/mixpanel.py
@@ -1,0 +1,643 @@
+# -*- coding: utf-8 -*-
+"""This is the official Mixpanel client library for Python.
+
+Mixpanel client libraries allow for tracking events and setting properties on
+People Analytics profiles from your server-side projects. This is the API
+documentation you may also be interested in the higher-level `usage
+documentation`_. If your users are interacting with your application via the
+web, you may also be interested in our `JavaScript library`_.
+
+.. _`Javascript library`: https://developer.mixpanel.com/docs/javascript
+.. _`usage documentation`: https://developer.mixpanel.com/docs/python
+
+:class:`~.Mixpanel` is the primary class for tracking events and sending People
+Analytics updates. :class:`~.Consumer` and :class:`~.BufferedConsumer` allow
+callers to customize the IO characteristics of their tracking.
+"""
+from __future__ import absolute_import, unicode_literals
+import base64
+import datetime
+import json
+import time
+
+import six
+from six.moves import urllib
+
+__version__ = '4.6.0'
+VERSION = __version__  # TODO: remove when bumping major version.
+
+
+class DatetimeSerializer(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            fmt = '%Y-%m-%dT%H:%M:%S'
+            return obj.strftime(fmt)
+
+        return json.JSONEncoder.default(self, obj)
+
+
+def json_dumps(data, cls=None):
+    # Separators are specified to eliminate whitespace.
+    return json.dumps(data, separators=(',', ':'), cls=cls)
+
+
+class Mixpanel(object):
+    """Instances of Mixpanel are used for all events and profile updates.
+
+    :param str token: your project's Mixpanel token
+    :param consumer: can be used to alter the behavior of tracking (default
+        :class:`~.Consumer`)
+    :param json.JSONEncoder serializer: a JSONEncoder subclass used to handle
+        JSON serialization (default :class:`~.DatetimeSerializer`)
+
+    See `Built-in consumers`_ for details about the consumer interface.
+
+    .. versionadded:: 4.2.0
+        The *serializer* parameter.
+    """
+
+    def __init__(self, token, consumer=None, serializer=DatetimeSerializer):
+        self._token = token
+        self._consumer = consumer or Consumer()
+        self._serializer = serializer
+
+    def _now(self):
+        return time.time()
+
+    def track(self, distinct_id, event_name, properties=None, meta=None):
+        """Record an event.
+
+        :param str distinct_id: identifies the user triggering the event
+        :param str event_name: a name describing the event
+        :param dict properties: additional data to record; keys should be
+            strings, and values should be strings, numbers, or booleans
+        :param dict meta: overrides Mixpanel special properties
+
+        ``properties`` should describe the circumstances of the event, or
+        aspects of the source or user associated with it. ``meta`` is used
+        (rarely) to override special values sent in the event object.
+        """
+        all_properties = {
+            'token': self._token,
+            'distinct_id': distinct_id,
+            'time': int(self._now()),
+            'mp_lib': 'python',
+            '$lib_version': __version__,
+        }
+        if properties:
+            all_properties.update(properties)
+        event = {
+            'event': event_name,
+            'properties': all_properties,
+        }
+        if meta:
+            event.update(meta)
+        self._consumer.send('events', json_dumps(event, cls=self._serializer))
+
+    def import_data(self, api_key, distinct_id, event_name, timestamp,
+                    properties=None, meta=None):
+        """Record an event that occured more than 5 days in the past.
+
+        :param str api_key: your Mixpanel project's API key
+        :param str distinct_id: identifies the user triggering the event
+        :param str event_name: a name describing the event
+        :param int timestamp: UTC seconds since epoch
+        :param dict properties: additional data to record; keys should be
+            strings, and values should be strings, numbers, or booleans
+        :param dict meta: overrides Mixpanel special properties
+
+        To avoid accidentally recording invalid events, the Mixpanel API's
+        ``track`` endpoint disallows events that occurred too long ago. This
+        method can be used to import such events. See our online documentation
+        for `more details
+        <https://developer.mixpanel.com/docs/importing-old-events>`__.
+        """
+        all_properties = {
+            'token': self._token,
+            'distinct_id': distinct_id,
+            'time': int(timestamp),
+            'mp_lib': 'python',
+            '$lib_version': __version__,
+        }
+        if properties:
+            all_properties.update(properties)
+        event = {
+            'event': event_name,
+            'properties': all_properties,
+        }
+        if meta:
+            event.update(meta)
+        self._consumer.send('imports', json_dumps(event, cls=self._serializer), api_key)
+
+    def alias(self, alias_id, original, meta=None):
+        """Creates an alias which Mixpanel will use to remap one id to another.
+
+        :param str alias_id: A distinct_id to be merged with the original
+            distinct_id. Each alias can only map to one distinct_id.
+        :param str original: A distinct_id to be merged with alias_id.
+        :param dict meta: overrides Mixpanel special properties
+
+        Immediately creates a one-way mapping between two ``distinct_ids``.
+        Events triggered by the new id will be associated with the existing
+        user's profile and behavior. See our online documentation for `more
+        details
+        <https://developer.mixpanel.com/docs/http#section-create-alias>`__.
+
+        .. note::
+            Calling this method *always* results in a synchronous HTTP request
+            to Mixpanel servers, regardless of any custom consumer.
+        """
+        sync_consumer = Consumer()
+        event = {
+            'event': '$create_alias',
+            'properties': {
+                'distinct_id': original,
+                'alias': alias_id,
+                'token': self._token,
+            },
+        }
+        if meta:
+            event.update(meta)
+        sync_consumer.send('events', json_dumps(event, cls=self._serializer))
+
+    def merge(self, api_key, distinct_id1, distinct_id2, meta=None):
+        """
+        Merges the two given distinct_ids.
+
+        :param str api_key: Your Mixpanel project's API key.
+        :param str distinct_id1: The first distinct_id to merge.
+        :param str distinct_id2: The second (other) distinct_id to merge.
+        :param dict meta: overrides Mixpanel special properties
+
+        See our online documentation for `more
+        details
+        <https://developer.mixpanel.com/docs/http#merge>`__.
+        """
+        event = {
+            'event': '$merge',
+            'properties': {
+                '$distinct_ids': [distinct_id1, distinct_id2],
+                'token': self._token,
+            },
+        }
+        if meta:
+            event.update(meta)
+        self._consumer.send('imports', json_dumps(event, cls=self._serializer), api_key)
+
+    def people_set(self, distinct_id, properties, meta=None):
+        """Set properties of a people record.
+
+        :param str distinct_id: the profile to update
+        :param dict properties: properties to set
+        :param dict meta: overrides Mixpanel `special properties`_
+
+        .. _`special properties`: https://developer.mixpanel.com/docs/http#section-storing-user-profiles
+
+        If the profile does not exist, creates a new profile with these properties.
+        """
+        return self.people_update({
+            '$distinct_id': distinct_id,
+            '$set': properties,
+        }, meta=meta or {})
+
+    def people_set_once(self, distinct_id, properties, meta=None):
+        """Set properties of a people record if they are not already set.
+
+        :param str distinct_id: the profile to update
+        :param dict properties: properties to set
+
+        Any properties that already exist on the profile will not be
+        overwritten. If the profile does not exist, creates a new profile with
+        these properties.
+        """
+        return self.people_update({
+            '$distinct_id': distinct_id,
+            '$set_once': properties,
+        }, meta=meta or {})
+
+    def people_increment(self, distinct_id, properties, meta=None):
+        """Increment/decrement numerical properties of a people record.
+
+        :param str distinct_id: the profile to update
+        :param dict properties: properties to increment/decrement; values
+            should be numeric
+
+        Adds numerical values to properties of a people record. Nonexistent
+        properties on the record default to zero. Negative values in
+        ``properties`` will decrement the given property.
+        """
+        return self.people_update({
+            '$distinct_id': distinct_id,
+            '$add': properties,
+        }, meta=meta or {})
+
+    def people_append(self, distinct_id, properties, meta=None):
+        """Append to the list associated with a property.
+
+        :param str distinct_id: the profile to update
+        :param dict properties: properties to append
+
+        Adds items to list-style properties of a people record. Appending to
+        nonexistent properties results in a list with a single element. For
+        example::
+
+            mp.people_append('123', {'Items': 'Super Arm'})
+        """
+        return self.people_update({
+            '$distinct_id': distinct_id,
+            '$append': properties,
+        }, meta=meta or {})
+
+    def people_union(self, distinct_id, properties, meta=None):
+        """Merge the values of a list associated with a property.
+
+        :param str distinct_id: the profile to update
+        :param dict properties: properties to merge
+
+        Merges list values in ``properties`` with existing list-style
+        properties of a people record. Duplicate values are ignored. For
+        example::
+
+            mp.people_union('123', {'Items': ['Super Arm', 'Fire Storm']})
+        """
+        return self.people_update({
+            '$distinct_id': distinct_id,
+            '$union': properties,
+        }, meta=meta or {})
+
+    def people_unset(self, distinct_id, properties, meta=None):
+        """Permanently remove properties from a people record.
+
+        :param str distinct_id: the profile to update
+        :param list properties: property names to remove
+        """
+        return self.people_update({
+            '$distinct_id': distinct_id,
+            '$unset': properties,
+        }, meta=meta)
+
+    def people_remove(self, distinct_id, properties, meta=None):
+        """Permanently remove a value from the list associated with a property.
+
+        :param str distinct_id: the profile to update
+        :param dict properties: properties to remove
+
+        Removes items from list-style properties of a people record.
+        For example::
+
+            mp.people_remove('123', {'Items': 'Super Arm'})
+        """
+        return self.people_update({
+            '$distinct_id': distinct_id,
+            '$remove': properties,
+        }, meta=meta or {})
+
+    def people_delete(self, distinct_id, meta=None):
+        """Permanently delete a people record.
+
+        :param str distinct_id: the profile to delete
+        """
+        return self.people_update({
+            '$distinct_id': distinct_id,
+            '$delete': "",
+        }, meta=meta or None)
+
+    def people_track_charge(self, distinct_id, amount,
+                            properties=None, meta=None):
+        """Track a charge on a people record.
+
+        :param str distinct_id: the profile with which to associate the charge
+        :param numeric amount: number of dollars charged
+        :param dict properties: extra properties related to the transaction
+
+        Record that you have charged the current user a certain amount of
+        money. Charges recorded with this way will appear in the Mixpanel
+        revenue report.
+        """
+        if properties is None:
+            properties = {}
+        properties.update({'$amount': amount})
+        return self.people_append(
+            distinct_id, {'$transactions': properties or {}}, meta=meta or {}
+        )
+
+    def people_clear_charges(self, distinct_id, meta=None):
+        """Permanently clear all charges on a people record.
+
+        :param str distinct_id: the profile whose charges will be cleared
+        """
+        return self.people_unset(
+            distinct_id, ["$transactions"], meta=meta or {},
+        )
+
+    def people_update(self, message, meta=None):
+        """Send a generic update to Mixpanel people analytics.
+
+        :param dict message: the message to send
+
+        Callers are responsible for formatting the update message as documented
+        in the `Mixpanel HTTP specification`_. This method may be useful if you
+        want to use very new or experimental features of people analytics, but
+        please use the other ``people_*`` methods where possible.
+
+        .. _`Mixpanel HTTP specification`: https://developer.mixpanel.com/docs/http
+        """
+        record = {
+            '$token': self._token,
+            '$time': int(self._now() * 1000),
+        }
+        record.update(message)
+        if meta:
+            record.update(meta)
+        self._consumer.send('people', json_dumps(record, cls=self._serializer))
+
+
+    def group_set(self, group_key, group_id, properties, meta=None):
+        """Set properties of a group profile.
+
+        :param str group_key: the group key, e.g. 'company'
+        :param str group_id: the group to update
+        :param dict properties: properties to set
+        :param dict meta: overrides Mixpanel `special properties`_. (See also `Mixpanel.people_set`.)
+
+        If the profile does not exist, creates a new profile with these properties.
+        """
+        return self.group_update({
+            '$group_key': group_key,
+            '$group_id': group_id,
+            '$set': properties,
+        }, meta=meta or {})
+
+    def group_set_once(self, group_key, group_id, properties, meta=None):
+        """Set properties of a group profile if they are not already set.
+
+        :param str group_key: the group key, e.g. 'company'
+        :param str group_id: the group to update
+        :param dict properties: properties to set
+
+        Any properties that already exist on the profile will not be
+        overwritten. If the profile does not exist, creates a new profile with
+        these properties.
+        """
+        return self.group_update({
+            '$group_key': group_key,
+            '$group_id': group_id,
+            '$set_once': properties,
+        }, meta=meta or {})
+
+    def group_union(self, group_key, group_id, properties, meta=None):
+        """Merge the values of a list associated with a property.
+
+        :param str group_key: the group key, e.g. 'company'
+        :param str group_id: the group to update
+        :param dict properties: properties to merge
+
+        Merges list values in ``properties`` with existing list-style
+        properties of a group profile. Duplicate values are ignored. For
+        example::
+
+            mp.group_union('company', 'Acme Inc.', {'Items': ['Super Arm', 'Fire Storm']})
+        """
+        return self.group_update({
+            '$group_key': group_key,
+            '$group_id': group_id,
+            '$union': properties,
+        }, meta=meta or {})
+
+    def group_unset(self, group_key, group_id, properties, meta=None):
+        """Permanently remove properties from a group profile.
+
+        :param str group_key: the group key, e.g. 'company'
+        :param str group_id: the group to update
+        :param list properties: property names to remove
+        """
+        return self.group_update({
+            '$group_key': group_key,
+            '$group_id': group_id,
+            '$unset': properties,
+        }, meta=meta)
+
+    def group_remove(self, group_key, group_id, properties, meta=None):
+        """Permanently remove a value from the list associated with a property.
+
+        :param str group_key: the group key, e.g. 'company'
+        :param str group_id: the group to update
+        :param dict properties: properties to remove
+
+        Removes items from list-style properties of a group profile.
+        For example::
+
+            mp.group_remove('company', 'Acme Inc.', {'Items': 'Super Arm'})
+        """
+        return self.group_update({
+            '$group_key': group_key,
+            '$group_id': group_id,
+            '$remove': properties,
+        }, meta=meta or {})
+
+    def group_delete(self, group_key, group_id, meta=None):
+        """Permanently delete a group profile.
+
+        :param str group_key: the group key, e.g. 'company'
+        :param str group_id: the group to delete
+        """
+        return self.group_update({
+            '$group_key': group_key,
+            '$group_id': group_id,
+            '$delete': "",
+        }, meta=meta or None)
+
+    def group_update(self, message, meta=None):
+        """Send a generic group profile update
+
+        :param dict message: the message to send
+
+        Callers are responsible for formatting the update message as documented
+        in the `Mixpanel HTTP specification`_. This method may be useful if you
+        want to use very new or experimental features, but
+        please use the other ``group_*`` methods where possible.
+
+        .. _`Mixpanel HTTP specification`: https://developer.mixpanel.com/docs/http
+        """
+        record = {
+            '$token': self._token,
+            '$time': int(self._now() * 1000),
+        }
+        record.update(message)
+        if meta:
+            record.update(meta)
+        self._consumer.send('groups', json_dumps(record, cls=self._serializer))
+
+
+class MixpanelException(Exception):
+    """Raised by consumers when unable to send messages.
+
+    This could be caused by a network outage or interruption, or by an invalid
+    endpoint passed to :meth:`.Consumer.send`.
+    """
+    pass
+
+
+class Consumer(object):
+    """
+    A consumer that sends an HTTP request directly to the Mixpanel service, one
+    per call to :meth:`~.send`.
+
+    :param str events_url: override the default events API endpoint
+    :param str people_url: override the default people API endpoint
+    :param str import_url: override the default import API endpoint
+    :param int request_timeout: connection timeout in seconds
+    :param str groups_url: override the default groups API endpoint
+    :param str api_host: the Mixpanel API domain where all requests should be
+        issued (unless overridden by above URLs).
+
+    .. versionadded:: 4.6.0
+        The *api_host* parameter.
+    """
+
+    def __init__(self, events_url=None, people_url=None, import_url=None,
+            request_timeout=None, groups_url=None, api_host="api.mixpanel.com"):
+        self._endpoints = {
+            'events': events_url or 'https://{}/track'.format(api_host),
+            'people': people_url or 'https://{}/engage'.format(api_host),
+            'groups': groups_url or 'https://{}/groups'.format(api_host),
+            'imports': import_url or 'https://{}/import'.format(api_host),
+        }
+        self._request_timeout = request_timeout
+
+    def send(self, endpoint, json_message, api_key=None):
+        """Immediately record an event or a profile update.
+
+        :param endpoint: the Mixpanel API endpoint appropriate for the message
+        :type endpoint: "events" | "people" | "imports"
+        :param str json_message: a JSON message formatted for the endpoint
+        :param str api_key: your Mixpanel project's API key
+        :raises MixpanelException: if the endpoint doesn't exist, the server is
+            unreachable, or the message cannot be processed
+        """
+        if endpoint in self._endpoints:
+            self._write_request(self._endpoints[endpoint], json_message, api_key)
+        else:
+            raise MixpanelException('No such endpoint "{0}". Valid endpoints are one of {1}'.format(endpoint, self._endpoints.keys()))
+
+    def _write_request(self, request_url, json_message, api_key=None):
+        data = {
+            'data': base64.b64encode(json_message.encode('utf8')),
+            'verbose': 1,
+            'ip': 1,
+        }
+        if api_key:
+            data.update({'api_key': api_key})
+        encoded_data = urllib.parse.urlencode(data).encode('utf8')
+        
+        try:
+            request = urllib.request.Request(request_url, encoded_data)
+
+            # Note: We don't send timeout=None here, because the timeout in urllib2 defaults to
+            # an internal socket timeout, not None.
+            if self._request_timeout is not None:
+                response = urllib.request.urlopen(request, timeout=self._request_timeout).read()
+            else:
+                response = urllib.request.urlopen(request).read()
+        except urllib.error.URLError as e:
+            six.raise_from(MixpanelException(e), e)
+
+        try:
+            response = json.loads(response.decode('utf8'))
+        except ValueError:
+            raise MixpanelException('Cannot interpret Mixpanel server response: {0}'.format(response))
+
+        if response['status'] != 1:
+            raise MixpanelException('Mixpanel error: {0}'.format(response['error']))
+
+        return True
+
+
+class BufferedConsumer(object):
+    """
+    A consumer that maintains per-endpoint buffers of messages and then sends
+    them in batches. This can save bandwidth and reduce the total amount of
+    time required to post your events to Mixpanel.
+
+    :param int max_size: number of :meth:`~.send` calls for a given endpoint to
+        buffer before flushing automatically
+    :param str events_url: override the default events API endpoint
+    :param str people_url: override the default people API endpoint
+    :param str import_url: override the default import API endpoint
+    :param int request_timeout: connection timeout in seconds
+    :param str groups_url: override the default groups API endpoint
+    :param str api_host: the Mixpanel API domain where all requests should be
+        issued (unless overridden by above URLs).
+
+    .. versionadded:: 4.6.0
+        The *api_host* parameter.
+
+    .. note::
+        Because :class:`~.BufferedConsumer` holds events, you need to call
+        :meth:`~.flush` when you're sure you're done sending them for example,
+        just before your program exits. Calls to :meth:`~.flush` will send all
+        remaining unsent events being held by the instance.
+    """
+    def __init__(self, max_size=50, events_url=None, people_url=None, import_url=None,
+            request_timeout=None, groups_url=None, api_host="api.mixpanel.com"):
+        self._consumer = Consumer(events_url, people_url, import_url, request_timeout, groups_url, api_host)
+        self._buffers = {
+            'events': [],
+            'people': [],
+            'groups': [],
+            'imports': [],
+        }
+        self._max_size = min(50, max_size)
+        self._api_key = None
+
+    def send(self, endpoint, json_message, api_key=None):
+        """Record an event or profile update.
+
+        Internally, adds the message to a buffer, and then flushes the buffer
+        if it has reached the configured maximum size. Note that exceptions
+        raised may have been caused by a message buffered by an earlier call to
+        :meth:`~.send`.
+
+        :param endpoint: the Mixpanel API endpoint appropriate for the message
+        :type endpoint: 'events' | 'people' | 'imports'
+        :param str json_message: a JSON message formatted for the endpoint
+        :param str api_key: your Mixpanel project's API key
+        :raises MixpanelException: if the endpoint does not exist, the server is
+            unreachable, or any buffered message cannot be processed
+
+        .. versionadded:: 4.3.2
+            The *api_key* parameter.
+        """
+        if endpoint not in self._buffers:
+            raise MixpanelException('No such endpoint "{0}". Valid endpoints are one of {1}'.format(endpoint, self._buffers.keys()))
+
+        buf = self._buffers[endpoint]
+        buf.append(json_message)
+        if api_key is not None:
+            self._api_key = api_key
+        if len(buf) >= self._max_size:
+            self._flush_endpoint(endpoint)
+
+    def flush(self):
+        """Immediately send all buffered messages to Mixpanel.
+
+        :raises MixpanelException: if the server is unreachable or any buffered
+            message cannot be processed
+        """
+        for endpoint in self._buffers.keys():
+            self._flush_endpoint(endpoint)
+
+    def _flush_endpoint(self, endpoint):
+        buf = self._buffers[endpoint]
+        while buf:
+            batch = buf[:self._max_size]
+            batch_json = '[{0}]'.format(','.join(batch))
+            try:
+                self._consumer.send(endpoint, batch_json, self._api_key)
+            except MixpanelException as orig_e:
+                mp_e = MixpanelException(orig_e)
+                mp_e.message = batch_json
+                mp_e.endpoint = endpoint
+                six.raise_from(mp_e, orig_e)
+            buf = buf[self._max_size:]
+        self._buffers[endpoint] = buf

--- a/zetaforge/mixpanel_client.py
+++ b/zetaforge/mixpanel_client.py
@@ -1,14 +1,33 @@
-import mixpanel
+from .mixpanel import Mixpanel
 import uuid
 from hashlib import sha256
+import platform
+import os
+from pathlib import Path
+import json
+#mixpanel client is created in different parts of the code, using singleton design pattern to prevent creating multiple 
+#instance.
 
-class MixpanelClient:
+class Singleton(type):
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+class MixpanelClient():
 
-    def __init__(self, token, enabled=True):
+    def __init__(self, token, enabled=True, is_dev=False):
         self.enabled = enabled
         self.token = token
+        os_ = platform.system()
+        self.is_dev = is_dev
+
+        self.os = os_
+        if os_ == 'Darwin':
+            self.os = 'Mac OS X'
+        
         try:
-            self.mp = mixpanel.Mixpanel(token)
+            self.mp = Mixpanel(token)
         except Exception as err:
             print("Exception occurred while initializing the mixpanel instance.")
             print(err)
@@ -21,8 +40,7 @@ class MixpanelClient:
     def set_people(self):
         if self.enabled:
             try:
-                # user = {"$first_name": self.distinct_id, '$last_name': self.distinct_id}
-                self.mp.people_set(self.distinct_id, {}, meta={})
+                self.mp.people_set_once(self.distinct_id, {'$os': self.os})
             except Exception as err:
                 print("Error happened while setting user profile. Disabling mixpanel")
                 print(err)
@@ -31,7 +49,7 @@ class MixpanelClient:
     def track_event(self, event, props={}):
         if self.enabled:
             try:
-                self.mp.track(self.distinct_id, event, props)
+                self.mp.track(self.distinct_id, event, {**props, 'is_dev':self.is_dev, '$os': self.os})
             except Exception as err:
                 print("Cannot track the event. Disabling mixpanel")
                 print(err)
@@ -46,3 +64,11 @@ class MixpanelClient:
             
         distinct_id = sha256(str(seed).encode('utf-8')).hexdigest()
         return distinct_id
+
+    def set_env(self,env):
+        self.is_dev = env
+
+mixpanel_client =  MixpanelClient('4c09914a48f08de1dbe3dc4dd2dcf90d')
+            
+
+    


### PR DESCRIPTION
This MR is intended to improve trackings in Mixpanel and Sentry, for the pip launcher.
In addition, it also resolves #50 

To use mixpanel in dev mode:

**Pip launcher**: pass --is_dev flag for launch and setup(for e.g. zetaforge setup --is_dev), if not passed, it defaults to production. Note that, the launch also handles client and anvil to be run on dev env.

**Anvil**: In config.json, use ZetaforgeIsDev argument. If that argument is missing, then by default, mixpanel send the events to production)i.e. is_dev=False) (In other words, users doesn't have to pass this argument, it's only for the zetaforge developers) 

**Client/Frontend**: If the app is not built(i.e. runs with npm run dev), then it's dev environment. Otherwise, 
if the user passes --is_dev flag to executable file, then it will run on dev. If not passed the flag, then it's production. Note that, --is_dev is already handled by the pip launcher


