### PR TITLE
Add checks to ensure seaweed is running before a pipeline runs

### DIFF
--- a/frontend/src/components/ui/RunPipelineButton.jsx
+++ b/frontend/src/components/ui/RunPipelineButton.jsx
@@ -37,6 +37,19 @@ export default function RunPipelineButton({modalPopper, children, action}) {
 
     let pipelineSpecs = editor.convert_drawflow_to_block(pipeline.name, pipeline.data);
     const executionId = uuidv7();
+
+
+    try {
+      const res = await axios.get(`${import.meta.env.VITE_EXECUTOR}/ping`)
+      if (res.status != 200) {
+        throw Error()
+      }
+    } catch(error) {
+      setValidationErrorMsg(["Seaweed ping did not return ok. Please wait a few seconds and retry."])
+      setIsOpen(true)
+      return null;
+    }
+
     try {
       pipelineSpecs = await uploadParameterBlocks.mutateAsync({
         pipelineId: pipeline.id,

--- a/main.go
+++ b/main.go
@@ -226,6 +226,9 @@ func main() {
 
 	router.Use(sentrygin.New(sentrygin.Options{}))
 
+	router.GET("/ping", func(ctx *gin.Context) {
+		ctx.String(http.StatusOK, "pong")
+	})
 	router.POST("/execute", func(ctx *gin.Context) {
 		execution, err := validateJson[zjson.Execution](ctx.Request.Body)
 		if err != nil {


### PR DESCRIPTION
Anvil pings seaweed on startup to ensure that it is ready to serve files. The client pings anvil to check if it is ready to receive a pipeline.