### PR TITLE
Minor compilation error toast fixes

### DIFF
--- a/frontend/server/blockSerialization.js
+++ b/frontend/server/blockSerialization.js
@@ -1,7 +1,7 @@
 import { execFile, spawnSync } from "child_process";
 import { app } from "electron";
 import fs from "fs/promises";
-import path, { resolve } from "path";
+import path from "path";
 import { BLOCK_SPECS_FILE_NAME } from "../src/utils/constants";
 import { fileExists } from "./fileSystem";
 
@@ -48,10 +48,10 @@ export async function runTest(blockPath, blockKey) {
     throw new Error(`Could not find script for running tests: ${scriptPath}`)
   }
   
-  return new Promise(() => {
+  return new Promise((resolve, reject) => {
     execFile("python", [scriptPath, blockPath, blockKey], (error, stdout, stderr) => {
       if (error) {
-        rejects(error);
+        reject(error);
       }
 
       console.log(stdout);

--- a/frontend/src/components/ui/ToastWrapper.jsx
+++ b/frontend/src/components/ui/ToastWrapper.jsx
@@ -9,5 +9,5 @@ export default function ToastWrapper() {
     setCompilationErrorToast(false);
   };
 
-  return (<div class="absolute bottom-3 right-3">{compilationErrorToast && <CompilationErrorToast onClose={onClose} />}</div>)
+  return (<div class="absolute bottom-3 right-3 z-[9000]">{compilationErrorToast && <CompilationErrorToast onClose={onClose} />}</div>)
 }

--- a/frontend/src/components/ui/blockEditor/CompliationErrorToast.jsx
+++ b/frontend/src/components/ui/blockEditor/CompliationErrorToast.jsx
@@ -4,7 +4,7 @@ export default function CompilationErrorToast({ onClose }) {
   return (
     <ToastNotification
       aria-label="closes notification"
-      caption="Could not compile the compuations.py file. Execution will fail. Please fix computations.py to enable its excution."
+      caption="Could not compile the computations.py file. Execution will fail. Please fix computations.py to enable its execution."
       kind="error"
       onCloseButtonClick={onClose}
       onClose={onClose}
@@ -13,5 +13,6 @@ export default function CompilationErrorToast({ onClose }) {
       timeout={0}
       title="Computations Compilation Failed"
     />
-  )
+  );
 }
+


### PR DESCRIPTION
- Fix bad import and undefined function in a promise to run the tests
- Fix 2 typos with the compilation error toast
- Increase the error toast z-index 