### PR TITLE
F/go styleguide fix with resolved conflicts. 

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -186,7 +186,7 @@ func downloadFiles(ctx context.Context, sink string, prefix string, cfg Config) 
 func deleteFiles(ctx context.Context, prefix string, extraFiles []string, cfg Config) {
 	client, err := s3Client(ctx, cfg)
 	if err != nil {
-		log.Printf("Failed to delete files; err=%v", err)
+		log.Printf("failed to delete files; err=%v", err)
 		return
 	}
 
@@ -202,7 +202,7 @@ func deleteFiles(ctx context.Context, prefix string, extraFiles []string, cfg Co
 		Prefix: aws.String(prefix),
 	})
 	if err != nil {
-		log.Printf("Failed to delete files; err=%v", err)
+		log.Printf("failed to delete files; err=%v", err)
 	}
 
 	for _, content := range res.Contents {
@@ -219,7 +219,7 @@ func deleteFiles(ctx context.Context, prefix string, extraFiles []string, cfg Co
 
 	_, err = client.DeleteObjects(ctx, params)
 	if err != nil {
-		log.Printf("Failed to delete files; err=%v", err)
+		log.Printf("failed to delete files; err=%v", err)
 	}
 }
 
@@ -266,14 +266,14 @@ func streaming(ctx context.Context, name string, client clientcmd.ClientConfig) 
 	)
 
 	if err != nil {
-		log.Printf("Log stream error; err=%v", err)
+		log.Printf("log stream error; err=%v", err)
 		return
 	}
 
 	namespace, _, err := client.Namespace()
 
 	if err != nil {
-		log.Printf("Log stream error; err=%v", err)
+		log.Printf("log stream error; err=%v", err)
 		return
 	}
 
@@ -289,7 +289,7 @@ func streaming(ctx context.Context, name string, client clientcmd.ClientConfig) 
 		})
 
 		if err != nil {
-			log.Printf("Log stream error; err=%v", err)
+			log.Printf("log stream error; err=%v", err)
 			return
 		}
 
@@ -299,7 +299,7 @@ func streaming(ctx context.Context, name string, client clientcmd.ClientConfig) 
 			if err == io.EOF {
 				break
 			} else if err != nil {
-				log.Printf("Log stream error; err=%v", err)
+				log.Printf("log stream error; err=%v", err)
 				break
 			}
 			// Remove the square brackets from the string
@@ -313,7 +313,7 @@ func streaming(ctx context.Context, name string, client clientcmd.ClientConfig) 
 			if len(parts) >= 4 {
 				blockId = strings.Join(parts[2:len(parts)-1], "-")
 			} else {
-				fmt.Println("Invalid input string format")
+				fmt.Println("invalid input string format")
 			}
 			jsonObj := map[string]interface{}{
 				"blockId": blockId,
@@ -321,7 +321,7 @@ func streaming(ctx context.Context, name string, client clientcmd.ClientConfig) 
 			}
 			jsonData, err := json.Marshal(jsonObj)
 			if err != nil {
-				fmt.Printf("Failed to cast log to JSON: %v", err)
+				fmt.Printf("failed to cast log to JSON: %v", err)
 			}
 
 			// This writes stream output to log, mandatory
@@ -368,7 +368,7 @@ func runArgo(ctx context.Context, workflow *wfv1.Workflow, execution int64, clie
 	}
 
 	if err := addExecutionWorkflow(ctx, db, execution, workflow.Name); err != nil {
-		log.Printf("Failed to write workflow id to database; err=%v", err)
+		log.Printf("failed to write workflow id to database; err=%v", err)
 		return workflow, err
 	}
 
@@ -428,14 +428,14 @@ func deleteArgo(ctx context.Context, name string, client clientcmd.ClientConfig)
 	)
 
 	if err != nil {
-		log.Printf("Failed to delete workflow %s; err=%v", name, err)
+		log.Printf("failed to delete workflow %s; err=%v", name, err)
 		return
 	}
 
 	namespace, _, err := client.Namespace()
 
 	if err != nil {
-		log.Printf("Failed to delete workflow %s; err=%v", name, err)
+		log.Printf("failed to delete workflow %s; err=%v", name, err)
 		return
 	}
 
@@ -447,7 +447,7 @@ func deleteArgo(ctx context.Context, name string, client clientcmd.ClientConfig)
 	})
 
 	if err != nil {
-		log.Printf("Failed to delete workflow %s; err=%v", name, err)
+		log.Printf("failed to delete workflow %s; err=%v", name, err)
 	}
 }
 
@@ -462,14 +462,14 @@ func stopArgo(ctx context.Context, name string, client clientcmd.ClientConfig) e
 	)
 
 	if err != nil {
-		log.Printf("Failed to build an api client; err=%v", err)
+		log.Printf("failed to build an api client; err=%v", err)
 		return err
 	}
 
 	namespace, _, err := client.Namespace()
 
 	if err != nil {
-		log.Printf("Failed to stop workflow %s; err=%v", name, err)
+		log.Printf("failed to stop workflow %s; err=%v", name, err)
 		return err
 	}
 
@@ -480,7 +480,7 @@ func stopArgo(ctx context.Context, name string, client clientcmd.ClientConfig) e
 	})
 
 	if err != nil {
-		log.Printf("Failed to stop workflow %s; err=%v", name, err)
+		log.Printf("failed to stop workflow %s; err=%v", name, err)
 		return err
 	}
 
@@ -497,13 +497,13 @@ func terminateArgo(ctx context.Context, client clientcmd.ClientConfig, db *sql.D
 		},
 	)
 	if err != nil {
-		log.Printf("Failed to build an api client; err=%v", err)
+		log.Printf("failed to build an api client; err=%v", err)
 		return err
 	}
 
 	namespace, _, err := client.Namespace()
 	if err != nil {
-		log.Printf("Failed to stop workflow %s; err=%v", name, err)
+		log.Printf("failed to stop workflow %s; err=%v", name, err)
 		return err
 	}
 
@@ -513,11 +513,11 @@ func terminateArgo(ctx context.Context, client clientcmd.ClientConfig, db *sql.D
 		Namespace: namespace,
 	})
 	if err != nil {
-		log.Printf("Failed to get workflow %s; err=%v", name, err)
+		log.Printf("failed to get workflow %s; err=%v", name, err)
 		updateErr := updateExecutionStatus(ctx, db, id, "Failed")
 
 		if updateErr != nil {
-			log.Printf("Failed to update execution status for workflow %s; err=%v", name, err)
+			log.Printf("failed to update execution status for workflow %s; err=%v", name, err)
 		}
 
 		return err
@@ -529,14 +529,14 @@ func terminateArgo(ctx context.Context, client clientcmd.ClientConfig, db *sql.D
 			Namespace: namespace,
 		})
 		if err != nil {
-			log.Printf("Failed to stop workflow %s; err=%v", name, err)
+			log.Printf("failed to stop workflow %s; err=%v", name, err)
 			return err
 		}
 	}
 
 	err = updateExecutionStatus(ctx, db, id, "Failed")
 	if err != nil {
-		log.Printf("Failed to update execution status for workflow %s; err=%v", name, err)
+		log.Printf("failed to update execution status for workflow %s; err=%v", name, err)
 		return err
 	}
 
@@ -665,13 +665,13 @@ func localExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 	defer completeExecution(ctx, db, executionId)
 
 	if err := hub.OpenRoom(executionUuid); err != nil {
-		log.Printf("Failed to open log room; err=%v", err)
+		log.Printf("failed to open log room; err=%v", err)
 		return
 	}
 	defer hub.CloseRoom(executionUuid)
 
 	if err := upload(ctx, cfg.EntrypointFile, cfg.EntrypointFile, cfg); err != nil { // should never fail
-		log.Printf("Failed to upload entrypoint file; err=%v", err)
+		log.Printf("failed to upload entrypoint file; err=%v", err)
 		return
 	}
 
@@ -680,7 +680,7 @@ func localExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 
 	file, err := os.OpenFile(tempLog, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
-		log.Printf("Error creating pipeline log: %v", err)
+		log.Printf("error creating pipeline log: %v", err)
 	}
 
 	pipelineLogger := createLogger(executionUuid, file, func(message string, executionUuid string) {
@@ -737,17 +737,17 @@ func localExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 
 	jsonData, err := json.MarshalIndent(pipeline, "", "  ")
 	if err != nil {
-		log.Printf("Invalid pipeline.json; err=%v", err)
+		log.Printf("invalid pipeline.json; err=%v", err)
 		return
 	}
 	if err := uploadData(ctx, string(jsonData), s3Key+"/"+"pipeline.json", cfg); err != nil {
-		log.Printf("Failed to write pipeline.json; err=%v", err)
+		log.Printf("failed to write pipeline.json; err=%v", err)
 		return
 	}
 
 	workflow, blocks, err := translate(ctx, pipeline, "org", s3Key, build, cfg)
 	if err != nil {
-		log.Printf("Failed to translate the pipeline; err=%v", err)
+		log.Printf("failed to translate the pipeline; err=%v", err)
 		return
 	}
 
@@ -755,17 +755,17 @@ func localExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 
 	jsonWorkflow, err := json.MarshalIndent(&workflow, "", "  ")
 	if err != nil {
-		log.Printf("Invalid translated pipeline.json; err=%v", err)
+		log.Printf("invalid translated pipeline.json; err=%v", err)
 		return
 	}
 
 	if err := uploadData(ctx, string(jsonWorkflow), s3Key+"/"+"argo.json", cfg); err != nil {
-		log.Printf("Failed to write translated pipeline.json; err=%v", err)
+		log.Printf("failed to write translated pipeline.json; err=%v", err)
 		return
 	}
 
 	if err := updateExecutionJson(ctx, db, executionId, workflow); err != nil {
-		log.Printf("Failed to write workflow to database; err=%v", err)
+		log.Printf("failed to write workflow to database; err=%v", err)
 		return
 	}
 
@@ -785,7 +785,7 @@ func localExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 	}
 
 	if err := eg.Wait(); err != nil {
-		log.Printf("Error during pipeline execution; err=%v", err)
+		log.Printf("error during pipeline execution; err=%v", err)
 		return
 	}
 
@@ -795,13 +795,13 @@ func localExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 		defer deleteArgo(ctx, workflow.Name, client)
 	}
 	if err != nil {
-		log.Printf("Error during pipeline execution; err=%v", err)
+		log.Printf("error during pipeline execution; err=%v", err)
 		return
 	}
 	// needs to be called here in addition to in defer
 	// in defer, it seems the nodes go out of scope
 	if err := results(ctx, db, executionId, *pipeline, *workflow); err != nil {
-		log.Printf("Failed to save results; err=%v", err)
+		log.Printf("failed to save results; err=%v", err)
 	}
 }
 
@@ -810,16 +810,16 @@ func cleanupRun(ctx context.Context, db *sql.DB, executionId int64, executionUui
 	s3Key := pipeline.Id + "/" + executionUuid
 
 	if err := upload(ctx, tempLog, s3Key+"/"+executionUuid+".log", cfg); err != nil {
-		log.Printf("Failed to upload log: err=%v", err)
+		log.Printf("failed to upload log: err=%v", err)
 	}
 
 	if err := results(ctx, db, executionId, pipeline, workflow); err != nil {
-		log.Printf("Failed to save results; err=%v", err)
+		log.Printf("failed to save results; err=%v", err)
 	}
 
 	sink := filepath.Join(pipeline.Sink, "history", executionUuid)
 	if err := downloadFiles(ctx, sink, s3Key, cfg); err != nil {
-		log.Printf("Failed to download files; err=%v", err)
+		log.Printf("failed to download files; err=%v", err)
 	}
 }
 
@@ -830,7 +830,7 @@ func cloudExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 	defer completeExecution(ctx, db, executionId)
 
 	if err := hub.OpenRoom(pipeline.Id); err != nil {
-		log.Printf("Failed to open log room; err=%v", err)
+		log.Printf("failed to open log room; err=%v", err)
 		return
 	}
 	defer hub.CloseRoom(pipeline.Id)
@@ -839,12 +839,12 @@ func cloudExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 
 	workflow, _, err := translate(ctx, pipeline, "org", s3key, build, cfg)
 	if err != nil {
-		log.Printf("Failed to translate the pipeline; err=%v", err)
+		log.Printf("failed to translate the pipeline; err=%v", err)
 		return
 	}
 
 	if err := updateExecutionJson(ctx, db, executionId, workflow); err != nil {
-		log.Printf("Failed to write workflow to database; err=%v", err)
+		log.Printf("failed to write workflow to database; err=%v", err)
 		return
 	}
 
@@ -853,7 +853,7 @@ func cloudExecute(pipeline *zjson.Pipeline, executionId int64, executionUuid str
 		defer deleteArgo(ctx, workflow.Name, client)
 	}
 	if err != nil {
-		log.Printf("Error during pipeline execution; err=%v", err)
+		log.Printf("error during pipeline execution; err=%v", err)
 		return
 	}
 }
@@ -868,7 +868,7 @@ func getBuildContextStatus(pipeline *zjson.Pipeline, cfg Config) []zjson.BuildCo
 			s3Key := getKanikoBuildContextS3Key(&block, "org")
 
 			if err != nil {
-				log.Printf("Failed to get build context status; err=%v", err)
+				log.Printf("failed to get build context status; err=%v", err)
 				return buildContextStatus
 			}
 

--- a/main.go
+++ b/main.go
@@ -292,12 +292,12 @@ func main() {
 	ctx := context.Background()
 	file, err := os.ReadFile("config.json")
 	if err != nil {
-		log.Fatalf("Config file missing; err=%v", err)
+		log.Fatalf("config file missing; err=%v", err)
 		return
 	}
 	var config Config
 	if err := json.Unmarshal(file, &config); err != nil {
-		log.Fatalf("Config file invalid; err=%v", err)
+		log.Fatalf("config file invalid; err=%v", err)
 		return
 	}
 
@@ -307,17 +307,17 @@ func main() {
 
 	db, err := sql.Open("sqlite3", config.Database)
 	if err != nil {
-		log.Fatalf("Failed to load database; err=%v", err)
+		log.Fatalf("failed to load database; err=%v", err)
 	}
 
 	goose.SetBaseFS(migrations)
 
 	if err := goose.SetDialect(string(goose.DialectSQLite3)); err != nil {
-		log.Fatalf("Failed to set database dialect; err=%v", err)
+		log.Fatalf("failed to set database dialect; err=%v", err)
 	}
 
 	if err := goose.Up(db, "db/migrations"); err != nil {
-		log.Fatalf("Failed to migrate database; err=%v", err)
+		log.Fatalf("failed to migrate database; err=%v", err)
 	}
 
 	var client clientcmd.ClientConfig
@@ -353,7 +353,7 @@ func main() {
 	} else {
 		cacert, err := base64.StdEncoding.DecodeString(config.Cloud.CaCert)
 		if err != nil {
-			log.Fatalf("Invalid CA certificate; err=%v", err)
+			log.Fatalf("invalid CA certificate; err=%v", err)
 		}
 
 		cfg := clientcmdapi.NewConfig()
@@ -400,21 +400,21 @@ func main() {
 	router.POST("/execute", func(ctx *gin.Context) {
 		execution, err := validateJson[zjson.Execution](ctx.Request.Body)
 		if err != nil {
-			log.Printf("Invalid json request; err=%v", err)
+			log.Printf("invalid json request; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
 
 		res, err := createPipeline(ctx.Request.Context(), db, "org", execution.Pipeline)
 		if err != nil {
-			log.Printf("Failed to create pipeline; err=%v", err)
+			log.Printf("failed to create pipeline; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
 		newExecution, err := createExecution(ctx, db, res.ID, execution.Id)
 
 		if err != nil {
-			log.Printf("Failed to write execution to database; err=%v", err)
+			log.Printf("failed to write execution to database; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -426,13 +426,13 @@ func main() {
 
 		retData, err := filterPipeline(ctx, db, execution.Id)
 		if err != nil {
-			log.Printf("Failed to get pipeline record; err=%v", err)
+			log.Printf("failed to get pipeline record; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
 		response, err := newResponsePipelineExecution(retData, []string{})
 		if err != nil {
-			log.Printf("Failed to create response payload; err=%v", err)
+			log.Printf("failed to create response payload; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -469,7 +469,7 @@ func main() {
 	router.POST("/build-context-status", func(ctx *gin.Context) {
 		pipeline, err := validateJson[zjson.Pipeline](ctx.Request.Body)
 		if err != nil {
-			log.Printf("Invalid json request; err=%v", err)
+			log.Printf("invalid json request; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -484,7 +484,7 @@ func main() {
 		res, err := listRunningExecutions(ctx.Request.Context(), db)
 
 		if err != nil {
-			log.Printf("Failed to get running executions; err=%v", err)
+			log.Printf("failed to get running executions; err=%v", err)
 		}
 
 		var response []ResponseExecution
@@ -498,7 +498,7 @@ func main() {
 		executionId := ctx.Param("executionId")
 		res, err := getExecutionById(ctx.Request.Context(), db, executionId)
 		if err != nil {
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve execution"})
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve execution"})
 			return
 		}
 
@@ -506,7 +506,7 @@ func main() {
 		if res.Status == "Running" {
 			logData, err := readTempLog(tempLog)
 			if err != nil {
-				ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read temporary log"})
+				ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read temporary log"})
 				return
 			}
 			ctx.JSON(http.StatusOK, logData)
@@ -519,7 +519,7 @@ func main() {
 		res, err := getExecutionById(ctx.Request.Context(), db, executionId)
 
 		if err != nil {
-			log.Printf("Failed to get execution; err=%v", err)
+			log.Printf("failed to get execution; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -545,7 +545,7 @@ func main() {
 
 		res, err := createPipeline(ctx.Request.Context(), db, "org", pipeline)
 		if err != nil {
-			log.Printf("Failed to create pipeline; err=%v", err)
+			log.Printf("failed to create pipeline; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -600,7 +600,7 @@ func main() {
 
 		res, httpErr := filterPipelines(ctx, db, int64(limit), int64(offset))
 		if httpErr != nil {
-			log.Printf("Failed to get filter pipelines; err=%v", err)
+			log.Printf("failed to get filter pipelines; err=%v", err)
 			ctx.String(httpErr.Status(), err.Error())
 			return
 		}
@@ -613,7 +613,7 @@ func main() {
 			if execution.Status == "Running" {
 				logOutput, err = readTempLog(tempLog)
 				if err != nil {
-					fmt.Printf("Failed to retrieve writing log; err=%v", err)
+					fmt.Printf("failed to retrieve writing log; err=%v", err)
 				}
 			} else if execution.Status != "Pending" {
 				s3key = execution.Uuid + "/" + execution.Executionid + "/" + execution.Executionid + ".log"
@@ -622,7 +622,7 @@ func main() {
 				logOutput, err = readTempLog(tempLog)
 
 				if err != nil {
-					fmt.Printf("No temp log on the server; err=%v\n", err)
+					fmt.Printf("no temp log on the server; err=%v\n", err)
 				}
 			}
 			newRes, err := newResponsePipelinesExecution(execution, logOutput, s3key)
@@ -639,7 +639,7 @@ func main() {
 		hash := ctx.Param("hash")
 
 		if err := softDeletePipeline(ctx.Request.Context(), db, "org", uuid, hash); err != nil {
-			log.Printf("Failed to delete pipeline; err=%v", err)
+			log.Printf("failed to delete pipeline; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -649,7 +649,7 @@ func main() {
 		hash := ctx.Param("hash")
 
 		if err := deployPipeline(ctx.Request.Context(), db, "org", uuid, hash); err != nil {
-			log.Printf("Failed to deploy pipeline; err=%v", err)
+			log.Printf("failed to deploy pipeline; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -660,7 +660,7 @@ func main() {
 		res, err := listAllExecutions(ctx.Request.Context(), db, "org", uuid)
 
 		if err != nil {
-			log.Printf("Failed to list executions; err=%v", err)
+			log.Printf("failed to list executions; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -683,7 +683,7 @@ func main() {
 
 		res, httpErr := getExecution(ctx.Request.Context(), db, "org", uuid, hash, index)
 		if httpErr != nil {
-			log.Printf("Failed to delete execution; err=%v", err)
+			log.Printf("failed to delete execution; err=%v", err)
 			ctx.String(httpErr.Status(), httpErr.Error())
 			return
 		}
@@ -697,7 +697,7 @@ func main() {
 		res, err := listExecutions(ctx.Request.Context(), db, "org", uuid, hash)
 
 		if err != nil {
-			log.Printf("Failed to list executions; err=%v", err)
+			log.Printf("failed to list executions; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -714,7 +714,7 @@ func main() {
 		hash := ctx.Param("hash")
 		res, err := getPipeline(ctx.Request.Context(), db, "org", paramUuid, hash)
 		if err != nil {
-			log.Printf("Failed to get pipeline; err=%v", err)
+			log.Printf("failed to get pipeline; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -730,7 +730,7 @@ func main() {
 		hash := ctx.Param("hash")
 		res, err := getPipeline(ctx.Request.Context(), db, "org", paramUuid, hash)
 		if err != nil {
-			log.Printf("Failed to get pipeline; err=%v", err)
+			log.Printf("failed to get pipeline; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -751,7 +751,7 @@ func main() {
 		newExecution, err := createExecution(ctx, db, res.ID, executionId.String())
 
 		if err != nil {
-			log.Printf("Failed to write execution to database; err=%v", err)
+			log.Printf("failed to write execution to database; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}
@@ -778,7 +778,7 @@ func main() {
 		}
 
 		if err := softDeleteExecution(ctx.Request.Context(), db, "org", uuid, hash, index); err != nil {
-			log.Printf("Failed to delete execution; err=%v", err)
+			log.Printf("failed to delete execution; err=%v", err)
 			ctx.String(err.Status(), err.Error())
 			return
 		}

--- a/query.go
+++ b/query.go
@@ -194,7 +194,7 @@ func createPipeline(ctx context.Context, db *sql.DB, organization string, pipeli
 
 	tx, err := db.Begin()
 	if err != nil {
-		log.Printf("Failed to initialize transaction; err=%v", err)
+		log.Printf("failed to initialize transaction; err=%v", err)
 		return zdatabase.Pipeline{}, InternalServerError{err.Error()}
 	}
 	defer tx.Rollback()
@@ -220,7 +220,7 @@ func createPipeline(ctx context.Context, db *sql.DB, organization string, pipeli
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Printf("Failed to commit transaction; err=%v", err)
+		log.Printf("failed to commit transaction; err=%v", err)
 		return zdatabase.Pipeline{}, InternalServerError{err.Error()}
 	}
 
@@ -282,7 +282,7 @@ func listAllPipelines(ctx context.Context, db *sql.DB, organization string) ([]z
 func deployPipeline(ctx context.Context, db *sql.DB, organization string, uuid string, hash string) HTTPError {
 	tx, err := db.Begin()
 	if err != nil {
-		log.Printf("Failed to initialize transaction; err=%v", err)
+		log.Printf("failed to initialize transaction; err=%v", err)
 		return InternalServerError{err.Error()}
 	}
 	defer tx.Rollback()
@@ -304,7 +304,7 @@ func deployPipeline(ctx context.Context, db *sql.DB, organization string, uuid s
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Printf("Failed to commit transaction; err=%v", err)
+		log.Printf("failed to commit transaction; err=%v", err)
 		return InternalServerError{err.Error()}
 	}
 
@@ -408,7 +408,7 @@ func softDeleteExecution(ctx context.Context, db *sql.DB, organization string, u
 
 	tx, err := db.Begin()
 	if err != nil {
-		log.Printf("Failed to initialize transaction; err=%v", err)
+		log.Printf("failed to initialize transaction; err=%v", err)
 		return InternalServerError{err.Error()}
 	}
 	defer tx.Rollback()
@@ -433,7 +433,7 @@ func softDeleteExecution(ctx context.Context, db *sql.DB, organization string, u
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Printf("Failed to commit transaction; err=%v", err)
+		log.Printf("failed to commit transaction; err=%v", err)
 		return InternalServerError{err.Error()}
 	}
 
@@ -484,7 +484,7 @@ func getExecution(ctx context.Context, db *sql.DB, organization string, uuid str
 
 	tx, err := db.Begin()
 	if err != nil {
-		log.Printf("Failed to initialize transaction; err=%v", err)
+		log.Printf("failed to initialize transaction; err=%v", err)
 		return zdatabase.Execution{}, InternalServerError{err.Error()}
 	}
 	defer tx.Rollback()
@@ -510,7 +510,7 @@ func getExecution(ctx context.Context, db *sql.DB, organization string, uuid str
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Printf("Failed to commit transaction; err=%v", err)
+		log.Printf("failed to commit transaction; err=%v", err)
 		return zdatabase.Execution{}, InternalServerError{err.Error()}
 	}
 
@@ -520,7 +520,7 @@ func getExecution(ctx context.Context, db *sql.DB, organization string, uuid str
 func setSetupVersion(ctx context.Context, db *sql.DB, version string) (zdatabase.SetupVersion, error) {
 	tx, err := db.Begin()
 	if err != nil {
-		log.Printf("Failed to initialize transaction; err=%v", err)
+		log.Printf("failed to initialize transaction; err=%v", err)
 		return zdatabase.SetupVersion{}, InternalServerError{err.Error()}
 	}
 	defer tx.Rollback()
@@ -537,7 +537,7 @@ func setSetupVersion(ctx context.Context, db *sql.DB, version string) (zdatabase
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Printf("Failed to commit transaction; err=%v", err)
+		log.Printf("failed to commit transaction; err=%v", err)
 		return zdatabase.SetupVersion{}, InternalServerError{err.Error()}
 	}
 

--- a/setup.go
+++ b/setup.go
@@ -286,19 +286,19 @@ func migrate(ctx context.Context, resources map[string]string, config Config, cl
 func setup(ctx context.Context, config Config, client clientcmd.ClientConfig, db *sql.DB) {
 	clientConfig, err := client.ClientConfig()
 	if err != nil {
-		log.Fatalf("Failed to get client config; err=%v", err)
+		log.Fatalf("failed to get client config; err=%v", err)
 	}
 
 	log.Println("Starting Setup...")
 	resources, err := kubectlResources(clientConfig)
 	if err != nil {
-		log.Fatalf("Failed to fetch kubernetes resources; err=%v", err)
+		log.Fatalf("failed to fetch kubernetes resources; err=%v", err)
 	}
 	if err := kubectlApply(ctx, "setup/install.yaml", resources, clientConfig); err != nil {
-		log.Fatalf("Failed to install argo; err=%v", err)
+		log.Fatalf("failed to install argo; err=%v", err)
 	}
 	if err := migrate(ctx, resources, config, clientConfig, db); err != nil {
-		log.Fatalf("Failed to migrate bucket; err=%v", err)
+		log.Fatalf("failed to migrate bucket; err=%v", err)
 	}
 
 	signals := make(chan os.Signal, 1)
@@ -320,7 +320,7 @@ func setup(ctx context.Context, config Config, client clientcmd.ClientConfig, db
 			<-signals
 			log.Println("Starting Shutdown...")
 			if err := kubectlDelete(ctx, "setup/install.yaml", resources, clientConfig); err != nil {
-				log.Printf("Failed to delete argo; err=%v", err)
+				log.Printf("failed to delete argo; err=%v", err)
 			}
 			if stopBucketCh != nil {
 				close(stopBucketCh)
@@ -334,7 +334,7 @@ func setup(ctx context.Context, config Config, client clientcmd.ClientConfig, db
 			<-signals
 			log.Println("Starting Shutdown...")
 			if err := kubectlDelete(ctx, "setup/install.yaml", resources, clientConfig); err != nil {
-				log.Printf("Failed to delete argo; err=%v", err)
+				log.Printf("failed to delete argo; err=%v", err)
 			}
 			log.Println("Shutdown Successful")
 			signal.Stop(signals)
@@ -351,12 +351,12 @@ func setup(ctx context.Context, config Config, client clientcmd.ClientConfig, db
 func uninstall(ctx context.Context, client clientcmd.ClientConfig, db *sql.DB) {
 	clientConfig, err := client.ClientConfig()
 	if err != nil {
-		log.Fatalf("Failed to get client config; err=%v", err)
+		log.Fatalf("failed to get client config; err=%v", err)
 	}
 
 	resources, err := kubectlResources(clientConfig)
 	if err != nil {
-		log.Fatalf("Failed to fetch kubernetes resources; err=%v", err)
+		log.Fatalf("failed to fetch kubernetes resources; err=%v", err)
 	}
 
 	setupVersion, err := getSetupVersion(ctx, db)
@@ -368,6 +368,6 @@ func uninstall(ctx context.Context, client clientcmd.ClientConfig, db *sql.DB) {
 	}
 
 	if err := kubectlDelete(ctx, "setup/build-"+version+".yaml", resources, clientConfig); err != nil {
-		log.Fatalf("Failed to delete bucket; err=%v", err)
+		log.Fatalf("failed to delete bucket; err=%v", err)
 	}
 }


### PR DESCRIPTION
Observations
-  Error messages weren’t all following style guides, changed every error message to print out in lowercase.
- Changed client to c, and hub to h to maintain common go naming conventions (websocket.go) 
