### PR TITLE
Fix scroll issue with the tooltip

### DIFF
--- a/frontend/src/components/ui/Tooltip.jsx
+++ b/frontend/src/components/ui/Tooltip.jsx
@@ -2,9 +2,9 @@ export default function Tooltip({ children, label }) {
   return (
     <div className="group">
       {children}
-      <span className="invisible absolute -bottom-2 left-0 group-hover:visible">
-        <span className="tooltip fixed">{label}</span>
-      </span>
+      <div className="invisible absolute left-0 top-[24px] group-hover:visible">
+        <div className="tooltip">{label}</div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ui/library/LibraryPipelineTile.jsx
+++ b/frontend/src/components/ui/library/LibraryPipelineTile.jsx
@@ -1,6 +1,7 @@
 import { trpc } from "@/utils/trpc";
 import { Information } from "@carbon/icons-react";
-import { Tile, Tooltip } from "@carbon/react";
+import { Tile } from "@carbon/react";
+import Tooltip from "@/components/ui/Tooltip";
 
 const usePipelineCoverImagePath = (pipelineId) => {
   const { data, isLoading, error } = trpc.getPipelineCoverImagePath.useQuery({
@@ -33,36 +34,36 @@ export const LibraryPipelineTile = ({ pipeline, index }) => {
   };
 
   return (
-    <Tile
-      className="library-tile relative"
-      key={index}
-      draggable={true}
-      onDragStart={(ev) => {
-        dragStartHandlerPipeline(ev, pipeline);
-      }}
-    >
+    <Tile className="library-tile relative" key={index}>
       <div
-        className="library-header"
-        title={pipelineName}
-        style={{ backgroundColor: backgroundColor }}
+        draggable={true}
+        onDragStart={(ev) => {
+          dragStartHandlerPipeline(ev, pipeline);
+        }}
       >
-        {pipelineName}
-      </div>
-      <div className="image-container relative h-[128px] overflow-hidden">
-        {isLoading ? (
-          <div className="flex h-full items-center justify-center"></div>
-        ) : (
-          <img
-            src={coverImagePath}
-            alt={pipelineName}
-            className="absolute left-0 top-0 h-full w-full object-contain"
-            style={{ zIndex: 0, opacity: 1.0 }}
-            onError={handleImageError}
-          />
-        )}
+        <div
+          className="library-header"
+          title={pipelineName}
+          style={{ backgroundColor: backgroundColor }}
+        >
+          {pipelineName}
+        </div>
+        <div className="image-container relative h-[128px] overflow-hidden">
+          {isLoading ? (
+            <div className="flex h-full items-center justify-center"></div>
+          ) : (
+            <img
+              src={coverImagePath}
+              alt={pipelineName}
+              className="absolute left-0 top-0 h-full w-full object-contain"
+              style={{ zIndex: 0, opacity: 1.0 }}
+              onError={handleImageError}
+            />
+          )}
+        </div>
       </div>
       <div className="absolute bottom-1 left-2 z-10">
-        <Tooltip align="bottom-left" label={pipelineDescription}>
+        <Tooltip label={pipelineDescription}>
           <Information size={20} />
         </Tooltip>
       </div>

--- a/frontend/src/components/ui/library/LibraryTile.jsx
+++ b/frontend/src/components/ui/library/LibraryTile.jsx
@@ -43,36 +43,38 @@ export const LibraryTile = ({ block, index }) => {
   };
 
   return (
-    <Tile
-      className="library-tile relative"
+    <Tile className="library-tile relative" 
       key={index}
-      draggable={true}
-      onDragStart={(ev) => {
-        dragStartHandler(ev, block);
-      }}
     >
       <div
-        className="library-header"
-        title={blockName}
-        style={{ backgroundColor: backgroundColor }}
+        draggable={true}
+        onDragStart={(ev) => {
+          dragStartHandler(ev, block);
+        }}
       >
-        {blockName}
-      </div>
-      <div className="image-container relative h-[128px] overflow-hidden">
-        {isLoading ? (
-          <div className="flex h-full items-center justify-center"></div>
-        ) : (
-          <img
-            src={coverImagePath}
-            alt={blockName}
-            className="absolute left-0 top-0 h-full w-full object-contain"
-            style={{ zIndex: 0, opacity: 1.0 }}
-            onError={handleImageError}
-          />
-        )}
+        <div
+          className="library-header"
+          title={blockName}
+          style={{ backgroundColor: backgroundColor }}
+        >
+          {blockName}
+        </div>
+        <div className="image-container relative h-[128px] overflow-hidden">
+          {isLoading ? (
+            <div className="flex h-full items-center justify-center"></div>
+          ) : (
+            <img
+              src={coverImagePath}
+              alt={blockName}
+              className="absolute left-0 top-0 h-full w-full object-contain"
+              style={{ zIndex: 0, opacity: 1.0 }}
+              onError={handleImageError}
+            />
+          )}
+        </div>
       </div>
       <div className="absolute bottom-1 left-2 z-10">
-        <Tooltip defaultOpen align="bottom-left" label={blockDescription}>
+        <Tooltip label={blockDescription}>
           <Information size={20} />
         </Tooltip>
       </div>

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -107,7 +107,9 @@ main {
 }
 
 .tooltip {
-  max-width: 18rem;
+  width: 8rem;
+  max-height: 8rem;
+  overflow: hidden;
   padding: 0.5rem;
   border-radius: 2px;
   color: var(--tooltip-color);


### PR DESCRIPTION
Fixes #151 

- Shorten the tooltip so it doesn't overflow
- Display it at the right place after scrolling down
- Exclude the tooltip from the drag "ghost"
- Set a max height so the tooltip doesn't go over the lower tooltip
- Other small code quality fixes