### PR TITLE
fix for issue #147, Parameter blocks save only pipeline.json

### DIFF
--- a/frontend/server/pipelineSerialization.js
+++ b/frontend/server/pipelineSerialization.js
@@ -34,6 +34,11 @@ export async function saveBlock(blockKey, blockSpec, fromPath, toPath) {
   return newFolder;
 }
 
+//added a helper function to know if a block is a parameter block
+function isParameterBlock(blockSpec) {
+  return blockSpec && blockSpec.action && blockSpec.action.parameters;
+}
+
 export async function copyPipeline(pipelineSpecs, fromDir, toDir) {
   const bufferPath = path.resolve(process.cwd(), fromDir);
 
@@ -90,7 +95,7 @@ export async function copyPipeline(pipelineSpecs, fromDir, toDir) {
     }
 
     logger.debug(`saving ${key} from ${existingBlockPath} to ${newBlockPath}`);
-    if (existingBlockPath != newBlockPath) {
+    if (existingBlockPath != newBlockPath && !isParameterBlock(blockSpec)) {
       // if it's the same folder, don't try to copy it
       await fs.cp(existingBlockPath, newBlockPath, { recursive: true });
       await fs.writeFile(


### PR DESCRIPTION
This fix closes #147 

Created a helper function to identify whether a processing block is a parameter or container block. made some modifications to the copyPipeline function using the newly created helper function to ensure the core/blocks folder isn't also nested within the file when saving parameter block. 

The saved file now only contains the pipeline.json file. 